### PR TITLE
Fix callback variable name for non-200 responses

### DIFF
--- a/lib/createNewEnvironment.js
+++ b/lib/createNewEnvironment.js
@@ -20,11 +20,11 @@ module.exports = function ({ environmentJsonBody, apiKey, workspaceId }, callbac
 
   request(options, function (error, response, body) {
     if (error) {
-      return cb(new Error(`Error creating a environment ${environmentJsonBody.environment.name}:`, error));
+      return callback(new Error(`Error creating a environment ${environmentJsonBody.environment.name}: ${JSON.stringify(error)}`));
     }
 
     if (response.statusCode >= 400) {
-      return cb(new Error(`Postman API returned HTTP ${response.statusCode} with message:`, response.body));
+      return callback(new Error(`Postman API returned HTTP ${response.statusCode} with message: ${JSON.stringify(response.body)}`));
     }
 
     console.info(chalk.green.bold(`Successfully created environment ${environmentJsonBody.environment.name}`));


### PR DESCRIPTION
Callback variable was referred as cb instead of callback which caused an error to error.